### PR TITLE
Enable change of api endpoint

### DIFF
--- a/src/main/java/com/bitmovin/api/BitmovinApi.java
+++ b/src/main/java/com/bitmovin/api/BitmovinApi.java
@@ -148,7 +148,7 @@ public class BitmovinApi
 
         this.tenantID = tenantID;
         this.apiKey = apiKey;
-        this.apiUrl = apiUrl == null ? ApiUrls.API_ENDPOINT_WITH_PROTOCOL + "/v1/" : String.format("%s://%s/", useHttps ? "https" : "http", apiUrl);
+        this.apiUrl = apiUrl == null ? ApiUrls.API_ENDPOINT_WITH_PROTOCOL + "/v1/" : String.format("%s://%s", useHttps ? "https" : "http", apiUrl);
         ApiUrls.API_ENDPOINT_WITH_PROTOCOL = this.apiUrl;
 
         this.setDefaultHeaders();

--- a/src/main/java/com/bitmovin/api/BitmovinApi.java
+++ b/src/main/java/com/bitmovin/api/BitmovinApi.java
@@ -149,6 +149,7 @@ public class BitmovinApi
         this.tenantID = tenantID;
         this.apiKey = apiKey;
         this.apiUrl = apiUrl == null ? ApiUrls.API_ENDPOINT_WITH_PROTOCOL + "/v1/" : String.format("%s://%s/", useHttps ? "https" : "http", apiUrl);
+        ApiUrls.API_ENDPOINT_WITH_PROTOCOL = this.apiUrl;
 
         this.setDefaultHeaders();
         this.initContainers();

--- a/src/main/java/com/bitmovin/api/constants/ApiUrls.java
+++ b/src/main/java/com/bitmovin/api/constants/ApiUrls.java
@@ -7,8 +7,8 @@ package com.bitmovin.api.constants;
  */
 public class ApiUrls
 {
-    public static final String API_ENDPOINT = "api.bitmovin.com/v1";
-    public static final String API_ENDPOINT_WITH_PROTOCOL = "https://" + API_ENDPOINT;
+    public static String API_ENDPOINT = "api.bitmovin.com/v1";
+    public static String API_ENDPOINT_WITH_PROTOCOL = "https://" + API_ENDPOINT;
 
     public static final String analyticsQuery = "analytics/queries";
     public static final String analyticsLicenses = "analytics/licenses";


### PR DESCRIPTION
This is not a pretty change, but it preserves the external API to the library, and even fixes one confusion: when passing the `apiUrl` to the `BitmovinApi` constructors it behaves as one might expect it rather than ignoring it.