### PR TITLE
Feature/H264 adaptive quantization mode

### DIFF
--- a/src/main/java/com/bitmovin/api/encoding/codecConfigurations/H264VideoConfiguration.java
+++ b/src/main/java/com/bitmovin/api/encoding/codecConfigurations/H264VideoConfiguration.java
@@ -328,4 +328,23 @@ public class H264VideoConfiguration extends VideoConfiguration
     {
         this.openGop = openGop;
     }
+
+    public void setAdaptiveQuantizationMode(H264AdaptiveQuantizationMode adaptiveQuantizationMode)
+    {
+        this.adaptiveQuantizationMode = adaptiveQuantizationMode;
+    }
+    public H264AdaptiveQuantizationMode getAdaptiveQuantizationMode()
+    {
+        return this.adaptiveQuantizationMode;
+    }
+    public void setAdaptiveQuantizationStrength(Double adaptiveQuantizationStrength)
+    {
+        this.adaptiveQuantizationStrength = adaptiveQuantizationStrength;
+    }
+    public Double getAdaptiveQuantizationStrength()
+    {
+        return this.adaptiveQuantizationStrength;
+    }
+
+
 }

--- a/src/main/java/com/bitmovin/api/encoding/codecConfigurations/H264VideoConfiguration.java
+++ b/src/main/java/com/bitmovin/api/encoding/codecConfigurations/H264VideoConfiguration.java
@@ -333,18 +333,20 @@ public class H264VideoConfiguration extends VideoConfiguration
     {
         this.adaptiveQuantizationMode = adaptiveQuantizationMode;
     }
+
     public H264AdaptiveQuantizationMode getAdaptiveQuantizationMode()
     {
         return this.adaptiveQuantizationMode;
     }
+
     public void setAdaptiveQuantizationStrength(Double adaptiveQuantizationStrength)
     {
         this.adaptiveQuantizationStrength = adaptiveQuantizationStrength;
     }
+
     public Double getAdaptiveQuantizationStrength()
     {
         return this.adaptiveQuantizationStrength;
     }
-
 
 }

--- a/src/main/java/com/bitmovin/api/encoding/codecConfigurations/H264VideoConfiguration.java
+++ b/src/main/java/com/bitmovin/api/encoding/codecConfigurations/H264VideoConfiguration.java
@@ -70,6 +70,10 @@ public class H264VideoConfiguration extends VideoConfiguration
 
     private Boolean openGop;
 
+    private H264AdaptiveQuantizationMode adaptiveQuantizationMode;
+
+    private Double adaptiveQuantizationStrength;
+
     public H264VideoConfiguration()
     {
         this.setType(ConfigType.H264);

--- a/src/main/java/com/bitmovin/api/encoding/codecConfigurations/enums/H264AdaptiveQuantizationMode.java
+++ b/src/main/java/com/bitmovin/api/encoding/codecConfigurations/enums/H264AdaptiveQuantizationMode.java
@@ -1,0 +1,13 @@
+package com.bitmovin.api.encoding.codecConfigurations.enums;
+
+/**
+ * Created by pkanzow on 4/2/19.
+ */
+public enum H264AdaptiveQuantizationMode
+{
+    NONE,
+    DISABLED,
+    VARIANCE,
+    AUTO_VARIANCE,
+    AUTO_VARIANCE_DARK_SCENES
+}


### PR DESCRIPTION
This feature branch adds support for the Adaptive Quantization Mode by adding the following properties to the `H264VideoConfiguration`:

`AdaptiveQuantizationMode`
`AdaptiveQuantizationStrength`

See the API reference: 

https://bitmovin.com/docs/encoding/api-reference/sections/configurations#/Encoding/PostEncodingConfigurationsVideoH264

