### PR TITLE
Feature/HE AAC v1 SBR Signaling

### DIFF
--- a/src/main/java/com/bitmovin/api/encoding/codecConfigurations/HeAACv1AudioConfig.java
+++ b/src/main/java/com/bitmovin/api/encoding/codecConfigurations/HeAACv1AudioConfig.java
@@ -12,7 +12,7 @@ public class HeAACv1AudioConfig extends AudioConfiguration
 
     private boolean normalize;
 
-    private SBRSignaling sbrSignaling;
+    private SBRSignaling signaling;
 
     public HeAACv1AudioConfig()
     {
@@ -49,8 +49,8 @@ public class HeAACv1AudioConfig extends AudioConfiguration
         this.normalize = normalize;
     }
 
-    public SBRSignaling getSBRSignaling() { return this.sbrSignaling; }
+    public SBRSignaling getSignaling() { return this.signaling; }
 
-    public void setSBRSignaling(SBRSignaling sbrSignaling) { this.sbrSignaling = sbrSignaling; }
+    public void setSignaling(SBRSignaling signaling) { this.signaling = signaling; }
 
 }

--- a/src/main/java/com/bitmovin/api/encoding/codecConfigurations/HeAACv1AudioConfig.java
+++ b/src/main/java/com/bitmovin/api/encoding/codecConfigurations/HeAACv1AudioConfig.java
@@ -2,6 +2,7 @@ package com.bitmovin.api.encoding.codecConfigurations;
 
 import com.bitmovin.api.encoding.codecConfigurations.enums.ChannelLayout;
 import com.bitmovin.api.encoding.codecConfigurations.enums.ConfigType;
+import com.bitmovin.api.encoding.codecConfigurations.enums.SBRSignaling;
 
 public class HeAACv1AudioConfig extends AudioConfiguration
 {
@@ -10,6 +11,8 @@ public class HeAACv1AudioConfig extends AudioConfiguration
     private Integer volumeAdjust;
 
     private boolean normalize;
+
+    private SBRSignaling sbrSignaling;
 
     public HeAACv1AudioConfig()
     {
@@ -45,4 +48,9 @@ public class HeAACv1AudioConfig extends AudioConfiguration
     {
         this.normalize = normalize;
     }
+
+    public SBRSignaling getSBRSignaling() { return this.sbrSignaling; }
+
+    public void setSBRSignaling(SBRSignaling sbrSignaling) { this.sbrSignaling = sbrSignaling; }
+
 }

--- a/src/main/java/com/bitmovin/api/encoding/codecConfigurations/enums/SBRSignaling.java
+++ b/src/main/java/com/bitmovin/api/encoding/codecConfigurations/enums/SBRSignaling.java
@@ -8,6 +8,6 @@ public enum SBRSignaling
     DEFAULT,
     IMPLICIT,
     EXPLICIT_SBR,
-    EXPLICIT_HIERACHICAL
+    EXPLICIT_HIERARCHICAL
 }
 

--- a/src/main/java/com/bitmovin/api/encoding/codecConfigurations/enums/SBRSignaling.java
+++ b/src/main/java/com/bitmovin/api/encoding/codecConfigurations/enums/SBRSignaling.java
@@ -1,0 +1,13 @@
+package com.bitmovin.api.encoding.codecConfigurations.enums;
+
+/**
+ * Created by pkanzow on 4/2/19.
+ */
+public enum SBRSignaling
+{
+    DEFAULT,
+    IMPLICIT,
+    EXPLICIT_SBR,
+    EXPLICIT_HIERACHICAL
+}
+


### PR DESCRIPTION
This feature enables the setting of Signaling for the `HE AAC V1` codec. 

I made an encoding with the changes I made in `HeAACv1AudioConfig` and the encoding indeed included the Signaling settings (`EXPLICIT_SBR`): 

```
 "codecConfig": {
        "id": "264c899c-52db-41a4-b618-4ff04b2c0280",
        "createdAt": "2019-04-03T08:53:47.661+0000",
        "customDataCreatedAt": "2019-04-03T08:53:47.661+0000",
        "name": "my-he-aac-v1-128kbit-cc",
        "type": "HE_AAC_V1",
        "bitrate": 128000,
        "channelLayout": "NONE",
        "signaling": "EXPLICIT_SBR"
      }
```

The same worked also for `EXPLICIT_HIERARCHICAL`

```
 "codecConfig": {
        "id": "aee9f245-ddd0-48e9-9370-8428e408e576",
        "createdAt": "2019-04-03T09:21:17.813+0000",
        "customDataCreatedAt": "2019-04-03T09:21:17.813+0000",
        "name": "my-he-aac-v1-128kbit-cc",
        "type": "HE_AAC_V1",
        "bitrate": 128000,
        "channelLayout": "NONE",
        "signaling": "EXPLICIT_HIERARCHICAL"
      }
```