### PR TITLE
feature/remove full rd enum

### DIFF
--- a/src/main/java/com/bitmovin/api/encoding/codecConfigurations/enums/H264SubMe.java
+++ b/src/main/java/com/bitmovin/api/encoding/codecConfigurations/enums/H264SubMe.java
@@ -15,6 +15,5 @@ public enum H264SubMe
     RD_ALL,
     RD_REF_IP,
     RD_REF_ALL,
-    QPRD,
-    FULL_RD
+    QPRD
 }


### PR DESCRIPTION
FULL_RD slows down H264 encodes by 40% and does not improve quality.